### PR TITLE
Fix: Improve badge visibility

### DIFF
--- a/src/components/exposure/MonthSelect.tsx
+++ b/src/components/exposure/MonthSelect.tsx
@@ -1,3 +1,4 @@
+
 import React, { useEffect } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from '@/components/ui/badge';
@@ -40,7 +41,7 @@ export const MonthSelect: React.FC<MonthSelectProps> = ({
         </SelectContent>
       </Select>
       
-      {businessDays !== null && selectedMonth && <Badge variant="outline" className="bg-slate-100">
+      {businessDays !== null && selectedMonth && <Badge variant="outline" className="bg-blue-800 text-white">
           {businessDays} business days
         </Badge>}
     </div>;


### PR DESCRIPTION
Change the background color of the badge with the class `bg-slate-100` to dark blue to improve the visibility of the white text.